### PR TITLE
Do not overwrite original /etc/hosts when applying

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'vagrant', :git => 'git://github.com/mitchellh/vagrant.git', :tag => 'v1.1.5'
+gem 'rake'
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -8,5 +8,5 @@ namespace :gem do
 end
 
 task :test do
-  sh 'bash test/test.sh'
+  sh 'test/test.sh'
 end

--- a/lib/vagrant-hostmanager/hosts_file.rb
+++ b/lib/vagrant-hostmanager/hosts_file.rb
@@ -23,7 +23,7 @@ module VagrantPlugins
         # create the temporary hosts file
         path = env.tmp_path.join('hosts')
         File.open(path, 'w') do |file|
-          file << "127.0.0.1\tlocalhost\slocalhost.localdomain\n"
+          file << "\n"
 
           # add a hosts entry for each active machine matching the provider
           env.active_machines.each do |name, p|
@@ -50,7 +50,8 @@ module VagrantPlugins
             :name => machine.name
           })
           machine.communicate.upload(path, '/tmp/hosts')
-          machine.communicate.sudo("mv /tmp/hosts /etc/hosts")
+          machine.communicate.sudo("[ -f /etc/hosts.orig ] || cp /etc/hosts /etc/hosts.orig")
+          machine.communicate.sudo("cat /etc/hosts.orig /tmp/hosts > /etc/hosts")
         end
       end
     end

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -4,18 +4,20 @@
 Vagrant.require_plugin('vagrant-hostmanager')
 
 Vagrant.configure('2') do |config|
-  config.vm.box = 'precise64-chef11.2'
-  config.vm.box_url = 'https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_chef-11.2.0.box'
+  config.vm.box = 'precise32'
+  config.vm.box_url = 'http://files.vagrantup.com/precise32.box'
 
   config.hostmanager.auto_update = false
 
   config.vm.define :server1 do |server|
-    server.vm.hostname = 'fry'
+    server.vm.hostname = 'fry.example.org'
     server.vm.network :private_network, :ip => '10.0.5.2'
+    server.hostmanager.aliases = %w(fry42.example.org fry-old.example.org)
   end
 
   config.vm.define :server2 do |server|
-    server.vm.hostname = 'bender'
+    server.vm.hostname = 'bender.example.org'
     server.vm.network :private_network, :ip => '10.0.5.3'
+    server.hostmanager.aliases = %w(bender42.example.org bender-old.example.org)
   end
 end

--- a/test/functions.sh
+++ b/test/functions.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# cleanup
+cleanup_file="$(mktemp ${TMPDIR-"/tmp"}/trap_cleanup.XXXXXXXX)"
+
+cleanup_trap() {
+  set +e
+  . ${cleanup_file}
+  rm -f ${cleanup_file}
+}
+trap cleanup_trap INT EXIT TERM
+
+register_cleanup_function() {
+  echo "${@}" >> ${cleanup_file}
+}
+# /cleanup
+
+vagrant_ssh() {
+    local vm=$1; shift
+    local cfg=$(mktemp ${TMPDIR-"/tmp"}/vagrant_ssh.XXXXXXXX)
+    register_cleanup_function rm $cfg
+
+    vagrant ssh-config $vm | grep -A 100 ^Host > $cfg
+    ssh -F $cfg vagrant@$vm "${@}"
+}
+
+fail() {
+  local message=$1
+  echo "Failure: $message" 1>&2
+  exit 1
+}

--- a/test/server1.expected.hosts.file.txt
+++ b/test/server1.expected.hosts.file.txt
@@ -1,0 +1,12 @@
+127.0.0.1	localhost
+127.0.1.1	fry.example.org fry precise32
+
+# The following lines are desirable for IPv6 capable hosts
+::1     ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+
+10.0.5.2	fry.example.org fry42.example.org fry-old.example.org
+10.0.5.3	bender.example.org bender42.example.org bender-old.example.org

--- a/test/server1.prestine.hosts.file.txt
+++ b/test/server1.prestine.hosts.file.txt
@@ -1,0 +1,9 @@
+127.0.0.1	localhost
+127.0.1.1	fry.example.org fry precise32
+
+# The following lines are desirable for IPv6 capable hosts
+::1     ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters

--- a/test/server2.expected.hosts.file.txt
+++ b/test/server2.expected.hosts.file.txt
@@ -1,0 +1,12 @@
+127.0.0.1	localhost
+127.0.1.1	bender.example.org bender precise32
+
+# The following lines are desirable for IPv6 capable hosts
+::1     ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+
+10.0.5.2	fry.example.org fry42.example.org fry-old.example.org
+10.0.5.3	bender.example.org bender42.example.org bender-old.example.org

--- a/test/server2.post-server1-down.hosts.file.txt
+++ b/test/server2.post-server1-down.hosts.file.txt
@@ -1,0 +1,11 @@
+127.0.0.1	localhost
+127.0.1.1	bender.example.org bender precise32
+
+# The following lines are desirable for IPv6 capable hosts
+::1     ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+
+10.0.5.3	bender.example.org bender42.example.org bender-old.example.org

--- a/test/server2.prestine.hosts.file.txt
+++ b/test/server2.prestine.hosts.file.txt
@@ -1,0 +1,9 @@
+127.0.0.1	localhost
+127.0.1.1	bender.example.org bender precise32
+
+# The following lines are desirable for IPv6 capable hosts
+::1     ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,14 +1,38 @@
-cd test
+#!/bin/sh
+. $(dirname $0)/functions.sh
+cd $(dirname $0)
+set -e
 
+register_cleanup_function vagrant destroy -f
 vagrant up
+
+servers="server1 server2"
+
+for server in ${servers}; do
+  echo "[${server}] assert original output is what we expected"
+  actual=$(vagrant_ssh ${server} 'cat /etc/hosts')
+  expected=$(cat ${server}.prestine.hosts.file.txt)
+  [ "${actual}" == "${expected}" ] || fail "Original hosts file does not match what we expected for server ${server}"
+done
 
 vagrant hostmanager
 
-echo "[server1] /etc/hosts file:"
-vagrant ssh server1 -c 'cat /etc/hosts'
-echo "[server2] /etc/hosts file:"
-vagrant ssh server2 -c 'cat /etc/hosts'
+for server in ${servers}; do
+  echo "[${server}] assert output is what we expect after hostmanager"
+  actual=$(vagrant_ssh ${server} 'cat /etc/hosts')
+  expected=$(cat ${server}.expected.hosts.file.txt)
+  [ "${actual}" == "${expected}" ] || fail "Hosts file after hostmanager modifications do not match for server ${server}"
+done
 
-vagrant destroy -f
+# Assert running twice should replace custom entries
 
-cd ..
+vagrant hostmanager
+
+for server in ${servers}; do
+  echo "[${server}] assert output is what we expect after hostmanager was applied twice"
+  actual=$(vagrant_ssh ${server} 'cat /etc/hosts')
+  expected=$(cat ${server}.expected.hosts.file.txt)
+  [ "${actual}" == "${expected}" ] || fail "Hosts file after hostmanager modifications (take 2) do not match for server ${server}"
+done
+
+echo "All tests passed."


### PR DESCRIPTION
In order to preserve what Vagrant and/or the original OS set, append to the
/etc/hosts file rather than rewriting it completely. Also add appropriate test
cases for the component test included in the project.

Reviewed-by: Jonathan Provost jprovost.sh@gmail.com
